### PR TITLE
Fix centering issue on title when responding to smaller screen size

### DIFF
--- a/src/Components/Home/Home.scss
+++ b/src/Components/Home/Home.scss
@@ -26,8 +26,6 @@
 
 .mighty-title {
     font-size: 4em;
-    align-self: end;
-    // margin-left: .2em;
 }
 
 .toilet-title {


### PR DESCRIPTION
### What (if any) features are you implementing?
- None
### What (if anything) did you refactor?
- Needed to delete a single css rule that was throwing the title to the end of the page rather than centering it.